### PR TITLE
Losen decorator type to support any framework

### DIFF
--- a/packages/storybook/src/decorator.ts
+++ b/packages/storybook/src/decorator.ts
@@ -15,7 +15,7 @@ class Wrapper extends HTMLElement {
 
 customElements.define("atomico-decorator-wrapper", Wrapper);
 
-export const decorator: DecoratorFunction = (Story, context) => {
+export const decorator: DecoratorFunction<any> = (Story, context) => {
     let channel = addons.getChannel();
 
     if (!cache[context.id]) {


### PR DESCRIPTION
We still had some type issues when using the decorator in React and WebComponents storybooks – now it should finally work